### PR TITLE
Allow passing command line parameters to UrlCommandFactory.Register()

### DIFF
--- a/src/Commands/UrlCommandFactory.cs
+++ b/src/Commands/UrlCommandFactory.cs
@@ -21,16 +21,16 @@ namespace MyCompany
             return new UrlCommandFactory(commandService);
         }
 
-        internal void Register(int commandId, string url)
+        internal void Register(int commandId, string url, string args = "")
         {
             var cmdId = new CommandID(PackageGuids.MyCompany, commandId);
-            var cmd = new MenuCommand((s, e) => Execute(url), cmdId);
+            var cmd = new MenuCommand((s, e) => Execute(url, args), cmdId);
             _commandService.AddCommand(cmd);
         }
 
-        private static void Execute(string url)
+        private static void Execute(string url, string args)
         {
-            System.Diagnostics.Process.Start(url);
+            System.Diagnostics.Process.Start(url ,args);
         }
     }
 }


### PR DESCRIPTION
### Allow passing command line parameters as optional argument to UrlCommandFactory.Register()

Considering that the Register() method can be used to link to any folder/file on local drives and/or the company network, it only makes sense to add an optional string argument to Register() (and also Execute(), obviously).